### PR TITLE
Update dependency list for v3.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ and in the dependencies part of your app.gradle add:
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.squareup.okhttp3:okhttp:3.12.1'
     compile 'com.googlecode.libphonenumber:libphonenumber:8.4.2'
+    compile 'androidx.constraintlayout:constraintlayout:1.1.3'
+    compile 'me.relex:circleindicator:1.3.2'
 ```
 
 ### App Bar


### PR DESCRIPTION
`androidx.constraintlayout:constraintlayout:1.1.3` and `me.relex:circleindicator:1.3.2` are mentioned in the [v3.22.0 changelog](https://github.com/idnow/de.idnow.android/tree/de.idnow.android-3.22.0#3220), however, they were not added to the [dependency list](https://github.com/idnow/de.idnow.android/tree/de.idnow.android-3.22.0#additional-dependencies-to-add-in-your-appgradle).